### PR TITLE
Redirecting help-text to stderr

### DIFF
--- a/csv-to-instack.py
+++ b/csv-to-instack.py
@@ -10,22 +10,22 @@ def main(argv):
     try:
         opts, args = getopt.getopt(argv,"c",["csv="])
     except :
-        print "csv-to-instack.py --csv=<inputfile>"
+        print >> sys.stderr, "csv-to-instack.py --csv=<inputfile>"
         sys.exit(2)
 
     for opt, arg in opts:
        if opt == '-h':
-           print 'csv-to-instack.py --csv=<inputfile>'
+           print >> sys.stderr ,'csv-to-instack.py --csv=<inputfile>'
            sys.exit()
        elif opt in ("-c", "--csv"):
            inputfile = arg
     if inputfile == None : 
-        print "Error : No input file passed"
-        print "Usage:"
-        print "csv-to-instack.py --csv=<inputfile>"
+        print >> sys.stderr, "Error : No input file passed"
+        print >> sys.stderr, "Usage:"
+        print >> sys.stderr, "csv-to-instack.py --csv=<inputfile>"
         sys.exit(2)
 
-    print "Opening %s" % inputfile
+    print >> sys.stderr, "Opening %s" % inputfile
     csvFile =  open(inputfile)
     data = list(csv.reader(csvFile))
     


### PR DESCRIPTION
When using this too piping directly to a json-file, having the line
'opening XXX input file' in there is rather annoying
